### PR TITLE
Added ability to remove array value

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ var notOldQuery = $.query.toString();
 > "?action=view&section=info&id=123&type=string"
 var oldQueryAgain = $.query.REMOVE("type");
 > ?action=view&section=info&id=123
+var removeElementByValue = $.query.REMOVE('section', 'info');
+> ?action=view&id=123
+var newerQuery2 = $.query.set('testy[]', 'true').set('testy[]', 'false').set('testy[]', 'true');
+> ?action=view&id=123&testy[0]=true&testy[1]=false&testy[2]=true
+var removeElementByValue = $.query.REMOVE('testy', 'false');
+> ?action=view&id=123&testy[0]=true&testy[1]=true
 var emptyQuery = $.query.empty();
 > ""
 var stillTheSame = $.query.copy();

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var removeElementByValue = $.query.REMOVE('section', 'info');
 > ?action=view&id=123
 var newerQuery2 = $.query.set('testy[]', 'true').set('testy[]', 'false').set('testy[]', 'true');
 > ?action=view&id=123&testy[0]=true&testy[1]=false&testy[2]=true
-var removeElementByValue = $.query.REMOVE('testy', 'false');
+var removeElementByValue1 = $.query.REMOVE('testy', 'false');
 > ?action=view&id=123&testy[0]=true&testy[1]=true
 var emptyQuery = $.query.empty();
 > ""

--- a/jquery.query-object.js
+++ b/jquery.query-object.js
@@ -149,8 +149,8 @@ new function(settings) {
         }
         return this.SET(key, null).COMPACT();
       },
-      remove: function(key) {
-        return this.copy().REMOVE(key);
+      remove: function(key, val) {
+        return this.copy().REMOVE(key, val);
       },
       EMPTY: function() {
         var self = this;

--- a/jquery.query-object.js
+++ b/jquery.query-object.js
@@ -138,7 +138,15 @@ new function(settings) {
       set: function(key, val) {
         return this.copy().SET(key, val);
       },
-      REMOVE: function(key) {
+      REMOVE: function(key, val) {
+        if (val) {
+          var target = this.GET(key);
+          if (is(target, Array)) {
+            var index = $.inArray(val, target);
+            key = target.splice(index, 1);
+            key = key[index];
+          }
+        }
         return this.SET(key, null).COMPACT();
       },
       remove: function(key) {

--- a/jquery.query-object.js
+++ b/jquery.query-object.js
@@ -143,8 +143,14 @@ new function(settings) {
           var target = this.GET(key);
           if (is(target, Array)) {
             var index = $.inArray(val, target);
-            key = target.splice(index, 1);
-            key = key[index];
+            if (index >= 0) {
+              key = target.splice(index, 1);
+              key = key[index];
+            } else {
+              return;
+            }
+          } else if (val != target) {
+              return;
           }
         }
         return this.SET(key, null).COMPACT();


### PR DESCRIPTION
Added ability to remove array value.

Example:
url > ?test[]=test1&test[]=test2&test[]=test3
 $.query.REMOVE('test, 'test2');

Result:
url > ?test[]=test1&test[]=test3